### PR TITLE
update to jetbrains compose 1.2.2, add js target

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,12 +24,12 @@ import java.util.Properties
 
 plugins {
     // id("com.diffplug.spotless") version "5.14.0"
-    kotlin("multiplatform") version "1.7.10" apply false
-    id("com.android.library") version "7.3.0-rc01" apply false
-    id("com.android.application") version "7.3.0-rc01" apply false
-    id("org.jetbrains.compose") version "1.2.0-alpha01-dev774" apply false
+    kotlin("multiplatform") version "1.7.20" apply false
+    id("com.android.library") version "7.3.1" apply false
+    id("com.android.application") version "7.3.1" apply false
+    id("org.jetbrains.compose") version "1.2.2" apply false
     id("com.vanniktech.maven.publish") version "0.18.0"
-    id("org.jetbrains.dokka") version "1.7.10"
+    id("org.jetbrains.dokka") version "1.7.20"
     id("me.tylerbwong.gradle.metalava") version "0.2.1" apply false
     id("com.github.ben-manes.versions") version "0.42.0"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,9 @@ org.gradle.parallel=true
 
 kotlin.native.distribution.type=prebuilt
 kotlin.mpp.stability.nowarn=true
+org.jetbrains.compose.experimental.jscanvas.enabled=true
+org.jetbrains.compose.experimental.uikit.enabled=true
+org.jetbrains.compose.experimental.macos.enabled=true
 
 # Declare we support AndroidX
 android.useAndroidX=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,21 +1,21 @@
 [versions]
 
 compose = "1.2.1"
-composeCompiler = "1.2.0"
+composeCompiler = "1.3.2"
 composesnapshot = "-" # a single character = no snapshot
 
 # gradlePlugin and lint need to be updated together
-gradlePlugin = "7.3.0-rc01"
+gradlePlugin = "7.3.1"
 lintMinCompose = "30.0.0"
 
 ktlint = "0.45.2"
-kotlin = "1.7.10"
+kotlin = "1.7.20"
 coroutines = "1.6.4"
 okhttp = "3.12.13"
 coil = "1.3.2"
 
 androidxtest = "1.4.0"
-androidxnavigation = "2.5.0-rc02"
+androidxnavigation = "2.5.3"
 
 androidxannotation="1.4.0"
 

--- a/pager/build.gradle.kts
+++ b/pager/build.gradle.kts
@@ -40,6 +40,9 @@ kotlin {
             }
         }
     }
+    js(IR) {
+        browser()
+    }
     iosX64()
     iosArm64()
     iosSimulatorArm64()

--- a/snapper/build.gradle.kts
+++ b/snapper/build.gradle.kts
@@ -40,6 +40,9 @@ kotlin {
             }
         }
     }
+    js(IR) {
+        browser()
+    }
     iosX64()
     iosArm64()
     iosSimulatorArm64()


### PR DESCRIPTION
maybe this should be separated to two pull requests, but I needed a JS target for something and updated compose at the same time.
